### PR TITLE
fixed datepicker js file to reflect nasa date format

### DIFF
--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -1,1 +1,1 @@
-$('.datepicker').pickadate()
+$('.datepicker').pickadate({ format: 'yyyy-mm-dd' })


### PR DESCRIPTION
The Bootstrap datepicker window was using a date format that the NASA API cannot read, making it impossible for students to use the local site in development after they build working API calls.

Added "({ format: 'yyyy-mm-dd' })" to datepicker.js file to fix.